### PR TITLE
Custom probability cutoff in Cross Validation

### DIFF
--- a/lib/rumale/model_selection/grid_search_cv.rb
+++ b/lib/rumale/model_selection/grid_search_cv.rb
@@ -94,7 +94,7 @@ module Rumale
 
         param_combinations.each do |prm_set|
           prm_set.each do |prms|
-            report = perform_cross_validation(x, y, prms)
+            report = perform_cross_validation(x, y, prms.dup)
             store_cv_result(prms, report)
           end
         end
@@ -173,9 +173,10 @@ module Rumale
       end
 
       def perform_cross_validation(x, y, prms)
+        prob_cutoff = prms.delete(:prob_cutoff) #nil if not specified, removes the cutoff from prms (which is a dup)
         est = configurated_estimator(prms)
         cv = CrossValidation.new(estimator: est, splitter: @params[:splitter],
-                                 evaluator: @params[:evaluator], return_train_score: true)
+                                 evaluator: @params[:evaluator], prob_cutoff: prob_cutoff, return_train_score: true)
         cv.perform(x, y)
       end
 

--- a/lib/rumale/validation.rb
+++ b/lib/rumale/validation.rb
@@ -92,6 +92,11 @@ module Rumale
     end
 
     # @!visibility private
+    def check_params_float_or_nil(params = {})
+      check_params_type_or_nil(Float, params)
+    end
+
+    # @!visibility private
     def check_params_integer(params = {})
       check_params_type(Integer, params)
     end
@@ -110,6 +115,12 @@ module Rumale
     # @!visibility private
     def check_params_positive(params = {})
       params.compact.each { |k, v| raise ArgumentError, "Expect #{k} to be positive value" if v.negative? }
+      nil
+    end
+
+    # @!visibility private
+    def check_params_within_range(min, max, params = {})
+      params.compact.each { |k, v| raise ArgumentError, "Expect #{k} to be between #{min} and #{max}" if v < min || v > max }
       nil
     end
   end


### PR DESCRIPTION
Allow setting a custom probability cutoff for cross validation (which is helpful in the case of unbalanced data).
Also add possibility to have this cutoff as an extra gridsearch parameter.