### PR TITLE
:art: Use extern intead of RUBY_EXTERN

### DIFF
--- a/ext/rumale/tree.c
+++ b/ext/rumale/tree.c
@@ -1,6 +1,6 @@
 #include "tree.h"
 
-RUBY_EXTERN VALUE mRumale;
+extern VALUE mRumale;
 
 double* alloc_dbl_array(const long n_dimensions) {
   double* arr = ALLOC_N(double, n_dimensions);


### PR DESCRIPTION
Fixed by @nobu (#34)

Co-authored-by: nobu <nobu@ruby-lang.org>