### PR TITLE
Pairwise euclidian forwards emtpy y to squared_error

### DIFF
--- a/rumale-core/lib/rumale/pairwise_metric.rb
+++ b/rumale-core/lib/rumale/pairwise_metric.rb
@@ -13,7 +13,6 @@ module Rumale
     # @param y [Numo::DFloat] (shape: [n_samples_y, n_features])
     # @return [Numo::DFloat] (shape: [n_samples_x, n_samples_x] or [n_samples_x, n_samples_y] if y is given)
     def euclidean_distance(x, y = nil)
-      y = x if y.nil?
       Numo::NMath.sqrt(squared_error(x, y).abs)
     end
 


### PR DESCRIPTION
This allows x.transpose to be utilized in `squared_error` and reduces number of operations when x and y are the same.